### PR TITLE
Update/graal 21.1.0 & multiple TornadoVM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ Script to install [TornadoVM](https://github.com/beehive-lab/TornadoVM/)
 
 The scripts provided in this repository will compile/download OpenJDK, `cmake` and it will build TornadoVM.
 
-This installation script has been tested on Linux and OSx. 
+This installation script has been tested on Linux and OSx.
+Note that GraalVM Community Edition releases based on JDK8 are no longer being built for Mac OSx.
 
 ```bash
 TornadoVM installer for Linux and OSx
 Usage:
        --jdk8           : Install TornadoVM with OpenJDK 8  (Default)
-       --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 20.2.0)
-       --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 20.2.0)
+       --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 21.1.0)
+       --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 21.1.0)
+       --graal-jdk-16   : Install TornadoVM with GraalVM and JDK 16 (GraalVM 21.1.0)
        --corretto-11    : Install TornadoVM with Corretto JDK 11
-       --mandrel-11     : Install TornadoVM with Mandrel 20.2.0 (JDK 11)
+       --corretto-16    : Install TornadoVM with Corretto JDK 16
+       --mandrel-11     : Install TornadoVM with Mandrel 21.1.0 (JDK 11)
        --windows-jdk-11 : Install TornadoVM with Windows JDK 11
+       --windows-jdk-16 : Install TornadoVM with Windows JDK 16
        --help           : Print this help
 
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage:
 To use TornadoVM with OpenJDK 8:
 
 ```bash
-./tornadovmInstaller.sh --jk8
+./tornadovmInstaller.sh --jdk8
 # and follow instructions
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Usage:
        --mandrel-11     : Install TornadoVM with Mandrel 21.1.0 (JDK 11)
        --windows-jdk-11 : Install TornadoVM with Windows JDK 11
        --windows-jdk-16 : Install TornadoVM with Windows JDK 16
+       --opencl         : Install TornadoVM and build the OpenCL backend
+       --ptx            : Install TornadoVM and build the PTX backend
        --help           : Print this help
 
 ```

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -383,6 +383,8 @@ do
     opencl=true
   elif [[ "$flag" == '--ptx' ]]; then
     ptx=true
+  else
+    opencl=true
   fi
 done
 }

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -65,8 +65,8 @@ function downloadOpenJDK8() {
     if [[ "$platform" == 'linux' ]]; then
         echo "Downloading JDK8 with JVMCI... ~100MB"
         wget https://github.com/graalvm/graal-jvmci-8/releases/download/jvmci-21.1-b05/openjdk-8u292+09-jvmci-21.1-b05-linux-amd64.tar.gz
-        tar xvzf openjdk-8u262+10-jvmci-21.1-b05-linux-amd64.tar.gz
-        export JAVA_HOME=$JDK_BASE/openjdk1.8.0_262-jvmci-21.1-b05
+	tar xvzf openjdk-8u292+09-jvmci-21.1-b05-linux-amd64.tar.gz
+        export JAVA_HOME=$JDK_BASE/openjdk1.8.0_292-jvmci-21.1-b05
     elif [[ "$platform" == 'darwin' ]]; then
         echo "JDK8 with JVMCI for Mac OSx is not supported for Graal 21.1"
 	exit 0
@@ -119,7 +119,7 @@ function downloadCorretto11() {
     if [[ "$platform" == 'linux' ]]; then
         wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz
         tar xf amazon-corretto-11-x64-linux-jdk.tar.gz
-        export JAVA_HOME=$PWD/amazon-corretto-11.9.1-linux-x64
+        export JAVA_HOME=$PWD/amazon-corretto-11.0.11.9.1-linux-x64
     elif [[ "$platform" == 'darwin' ]]; then
 	wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz        
         tar xf amazon-corretto-11-x64-macos-jdk.tar.gz
@@ -144,8 +144,8 @@ function downloadMandrel11() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
         wget https://github.com/graalvm/mandrel/releases/download/mandrel-21.1.0.0-Final/mandrel-java11-linux-amd64-21.1.0.0-Final.tar.gz
-        tar xf mandrel-java11-linux-amd64-21.1.0.0.Final.tar.gz
-        export JAVA_HOME=$PWD/mandrel-java11-21.1.0.0.Final
+        tar xf mandrel-java11-linux-amd64-21.1.0.0-Final.tar.gz
+        export JAVA_HOME=$PWD/mandrel-java11-21.1.0.0-Final
     elif [[ "$platform" == 'darwin' ]]; then
         echo "OS Not supported"
         exit 0
@@ -155,9 +155,9 @@ function downloadMandrel11() {
 function downloadWindowsJDK11() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
-        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.10.9.1-linux-x64.tar.gz
+        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.11.9.1-linux-x64.tar.gz 
         tar xf microsoft-jdk-11.0.11.9.1-linux-x64.tar.gz
-        export JAVA_HOME=$PWD/jdk-11.0.11+9.1
+        export JAVA_HOME=$PWD/jdk-11.0.11+9
     elif [[ "$platform" == 'darwin' ]]; then
         wget https://aka.ms/download-jdk/microsoft-jdk-11.0.11.9.1-macOS-x64.tar.gz
 	tar xf microsoft-jdk-11.0.11.9.1-macos-x64.tar.gz        

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -27,7 +27,7 @@ function checkJavaVersion() {
     if [ -z "$JAVA_HOME" ];
     then
 	    echo "JAVA_HOME is not set. Use OpenJDK 8 >= 141 <= 1.9"
-    	    if [[ "$platform" == 'linux' ]]; then
+    	if [[ "$platform" == 'linux' ]]; then
 	    	# shellcheck disable=SC2028
 	    	echo "\t You can use \`ls -l /etc/alternatives/java\` to get the PATHs"
 	    elif [[ "$platform" == 'darwin' ]]; then
@@ -79,9 +79,9 @@ function downloadOpenJDK8() {
 function downloadGraalVMJDK8() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then	
-    	wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
-	    tar -xf graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
-	    export JAVA_HOME=$PWD/graalvm-ce-java8-21.1.0
+        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
+	tar -xf graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
+	export JAVA_HOME=$PWD/graalvm-ce-java8-21.1.0
     elif [[ "$platform" == 'darwin' ]]; then
         echo "JDK8 for Mac OSx is not supported for Graal 21.1"
 	exit 0
@@ -105,12 +105,12 @@ function downloadGraalVMJDK16() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
         wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java16-linux-amd64-21.1.0.tar.gz
-            tar -xf graalvm-ce-java16-linux-amd64-21.1.0.tar.gz
-            export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0
+        tar -xf graalvm-ce-java16-linux-amd64-21.1.0.tar.gz
+        export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0
     elif [[ "$platform" == 'darwin' ]]; then
         wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java16-darwin-amd64-21.1.0.tar.gz
-            tar -xf graalvm-ce-java16-darwin-amd64-21.1.0.tar.gz
-            export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0/Contents/Home/
+        tar -xf graalvm-ce-java16-darwin-amd64-21.1.0.tar.gz
+        export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0/Contents/Home/
     fi
 }
 
@@ -121,7 +121,7 @@ function downloadCorretto11() {
         tar xf amazon-corretto-11-x64-linux-jdk.tar.gz
         export JAVA_HOME=$PWD/amazon-corretto-11.0.11.9.1-linux-x64
     elif [[ "$platform" == 'darwin' ]]; then
-	wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz        
+	    wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz        
         tar xf amazon-corretto-11-x64-macos-jdk.tar.gz
         export JAVA_HOME=$PWD/amazon-corretto-11.jdk/Contents/Home
     fi

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -230,7 +230,18 @@ function setupTornadoVM() {
     cd TornadoVM
     export PATH=$PWD/bin/bin:$PATH
     export TORNADO_SDK=$PWD/bin/sdk
-    make $1
+    resolveBackends
+    make $1 $backend
+}
+
+function resolveBackends() {
+    if [[ "$opencl" && "$ptx" ]] ; then
+	backend="BACKEND=opencl,ptx"
+    elif [ "$ptx" ] ; then
+        backend="BACKEND=ptx"
+    else 
+    	backend="BACKEND=opencl"
+    fi 
 }
 
 function setupVariables() {
@@ -358,8 +369,22 @@ function printHelp() {
     echo "       --mandrel-11     : Install TornadoVM with Mandrel 21.1.0 (JDK 11)"
     echo "       --windows-jdk-11 : Install TornadoVM with Windows JDK 11"
     echo "       --windows-jdk-16 : Install TornadoVM with Windows JDK 16"
+    echo "       --opencl         : Install TornadoVM and build the OpenCL backend"
+    echo "       --ptx            : Install TornadoVM and build the PTX backend"
     echo "       --help           : Print this help"
     exit 0
+}
+
+function setBackend() {
+for i in ${args[@]}
+do
+  flag=$i
+  if [[ "$flag" == '--opencl' ]]; then
+    opencl=true
+  elif [[ "$flag" == '--ptx' ]]; then
+    ptx=true
+  fi
+done
 }
 
 POSITIONAL=()
@@ -370,8 +395,13 @@ then
     exit
 fi
 
-while [[ $# -gt 0 ]]; do
-  key="$1"
+args=( "$@" )
+
+setBackend
+
+for i in ${args[@]} 
+do
+  key=$i
   case $key in
   --help)
     printHelp
@@ -411,6 +441,12 @@ while [[ $# -gt 0 ]]; do
     ;;
   --windows-jdk-16)
     installForWindowsJDK16
+    shift
+    ;;
+  --opencl)
+    shift
+    ;;
+  --ptx)
     shift
     ;;
   *)

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -27,7 +27,7 @@ function checkJavaVersion() {
     if [ -z "$JAVA_HOME" ];
     then
 	    echo "JAVA_HOME is not set. Use OpenJDK 8 >= 141 <= 1.9"
-    	if [[ "$platform" == 'linux' ]]; then
+    	    if [[ "$platform" == 'linux' ]]; then
 	    	# shellcheck disable=SC2028
 	    	echo "\t You can use \`ls -l /etc/alternatives/java\` to get the PATHs"
 	    elif [[ "$platform" == 'darwin' ]]; then
@@ -64,14 +64,12 @@ function downloadOpenJDK8() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
         echo "Downloading JDK8 with JVMCI... ~100MB"
-        wget https://github.com/graalvm/graal-jvmci-8/releases/download/jvmci-20.2-b03/openjdk-8u262+10-jvmci-20.2-b03-linux-amd64.tar.gz
-        tar xvzf openjdk-8u262+10-jvmci-20.2-b03-linux-amd64.tar.gz
-        export JAVA_HOME=$JDK_BASE/openjdk1.8.0_262-jvmci-20.2-b03
+        wget https://github.com/graalvm/graal-jvmci-8/releases/download/jvmci-21.1-b05/openjdk-8u292+09-jvmci-21.1-b05-linux-amd64.tar.gz
+        tar xvzf openjdk-8u262+10-jvmci-21.1-b05-linux-amd64.tar.gz
+        export JAVA_HOME=$JDK_BASE/openjdk1.8.0_262-jvmci-21.1-b05
     elif [[ "$platform" == 'darwin' ]]; then
-        echo "Downloading JDK8 with JVMCI... ~100MB"
-        wget https://github.com/graalvm/graal-jvmci-8/releases/download/jvmci-20.2-b03/openjdk-8u262+10-jvmci-20.2-b03-darwin-amd64.tar.gz
-        tar xvzf openjdk-8u262+10-jvmci-20.2-b03-darwin-amd64.tar.gz
-        export JAVA_HOME=$JDK_BASE/openjdk1.8.0_262-jvmci-20.2-b03/Contents/Home/
+        echo "JDK8 with JVMCI for Mac OSx is not supported for Graal 21.1"
+	exit 0
     else
         echo "OS platform not supported"
         exit 0
@@ -81,26 +79,38 @@ function downloadOpenJDK8() {
 function downloadGraalVMJDK8() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then	
-    	wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java8-linux-amd64-20.2.0.tar.gz
-	    tar -xf graalvm-ce-java8-linux-amd64-20.2.0.tar.gz
-	    export JAVA_HOME=$PWD/graalvm-ce-java8-20.2.0
+    	wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
+	    tar -xf graalvm-ce-java8-linux-amd64-21.1.0.tar.gz
+	    export JAVA_HOME=$PWD/graalvm-ce-java8-21.1.0
     elif [[ "$platform" == 'darwin' ]]; then
-        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java8-darwin-amd64-20.2.0.tar.gz
-	    tar -xf graalvm-ce-java8-darwin-amd64-20.2.0.tar.gz
-	    export JAVA_HOME=$PWD/graalvm-ce-java8-20.2.0/Contents/Home/
+        echo "JDK8 for Mac OSx is not supported for Graal 21.1"
+	exit 0
     fi
 }
 
 function downloadGraalVMJDK11() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
-        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-linux-amd64-20.2.0.tar.gz
-	    tar -xf graalvm-ce-java11-linux-amd64-20.2.0.tar.gz
-	    export JAVA_HOME=$PWD/graalvm-ce-java11-20.2.0
+        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
+	    tar -xf graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
+	    export JAVA_HOME=$PWD/graalvm-ce-java11-21.1.0
     elif [[ "$platform" == 'darwin' ]]; then
-        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java11-darwin-amd64-20.2.0.tar.gz
-	    tar -xf graalvm-ce-java11-darwin-amd64-20.2.0.tar.gz
-	    export JAVA_HOME=$PWD/graalvm-ce-java11-20.2.0/Contents/Home/
+        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-darwin-amd64-21.1.0.tar.gz
+	    tar -xf graalvm-ce-java11-darwin-amd64-21.1.0.tar.gz
+	    export JAVA_HOME=$PWD/graalvm-ce-java11-21.1.0/Contents/Home/
+    fi
+}
+
+function downloadGraalVMJDK16() {
+    platform=$(getPlatform)
+    if [[ "$platform" == 'linux' ]]; then
+        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java16-linux-amd64-21.1.0.tar.gz
+            tar -xf graalvm-ce-java16-linux-amd64-21.1.0.tar.gz
+            export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0
+    elif [[ "$platform" == 'darwin' ]]; then
+        wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java16-darwin-amd64-21.1.0.tar.gz
+            tar -xf graalvm-ce-java16-darwin-amd64-21.1.0.tar.gz
+            export JAVA_HOME=$PWD/graalvm-ce-java16-21.1.0/Contents/Home/
     fi
 }
 
@@ -109,20 +119,33 @@ function downloadCorretto11() {
     if [[ "$platform" == 'linux' ]]; then
         wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz
         tar xf amazon-corretto-11-x64-linux-jdk.tar.gz
-        export JAVA_HOME=$PWD/amazon-corretto-11.0.9.12.1-linux-x64
+        export JAVA_HOME=$PWD/amazon-corretto-11.9.1-linux-x64
     elif [[ "$platform" == 'darwin' ]]; then
-        wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz
+	wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.tar.gz        
         tar xf amazon-corretto-11-x64-macos-jdk.tar.gz
         export JAVA_HOME=$PWD/amazon-corretto-11.jdk/Contents/Home
+    fi
+}
+
+function downloadCorretto16() {
+    platform=$(getPlatform)
+    if [[ "$platform" == 'linux' ]]; then
+        wget https://corretto.aws/downloads/latest/amazon-corretto-16-x64-linux-jdk.tar.gz
+        tar xf amazon-corretto-16-x64-linux-jdk.tar.gz
+        export JAVA_HOME=$PWD/amazon-corretto-16.0.1.9.1-linux-x64
+    elif [[ "$platform" == 'darwin' ]]; then
+        wget https://corretto.aws/downloads/latest/amazon-corretto-16-x64-macos-jdk.tar.gz
+        tar xf amazon-corretto-16-x64-macos-jdk.tar.gz
+        export JAVA_HOME=$PWD/amazon-corretto-16.jdk/Contents/Home
     fi
 }
 
 function downloadMandrel11() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
-        wget https://github.com/graalvm/mandrel/releases/download/mandrel-20.2.0.0.Final/mandrel-java11-linux-amd64-20.2.0.0.Final.tar.gz
-        tar xf mandrel-java11-linux-amd64-20.2.0.0.Final.tar.gz
-        export JAVA_HOME=$PWD/mandrel-java11-20.2.0.0.Final
+        wget https://github.com/graalvm/mandrel/releases/download/mandrel-21.1.0.0-Final/mandrel-java11-linux-amd64-21.1.0.0-Final.tar.gz
+        tar xf mandrel-java11-linux-amd64-21.1.0.0.Final.tar.gz
+        export JAVA_HOME=$PWD/mandrel-java11-21.1.0.0.Final
     elif [[ "$platform" == 'darwin' ]]; then
         echo "OS Not supported"
         exit 0
@@ -132,13 +155,26 @@ function downloadMandrel11() {
 function downloadWindowsJDK11() {
     platform=$(getPlatform)
     if [[ "$platform" == 'linux' ]]; then
-        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.10.9-linux-x64.tar.gz
-        tar xf microsoft-jdk-11.0.10.9-linux-x64.tar.gz
-        export JAVA_HOME=$PWD/jdk-11.0.10+9
+        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.10.9.1-linux-x64.tar.gz
+        tar xf microsoft-jdk-11.0.11.9.1-linux-x64.tar.gz
+        export JAVA_HOME=$PWD/jdk-11.0.11+9.1
     elif [[ "$platform" == 'darwin' ]]; then
-        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.10.9-macos-x64.tar.gz
-        tar xf microsoft-jdk-11.0.10.9-macos-x64.tar.gz
-        export JAVA_HOME=$PWD/jdk-11.0.10+9/Contents/Home
+        wget https://aka.ms/download-jdk/microsoft-jdk-11.0.11.9.1-macOS-x64.tar.gz
+	tar xf microsoft-jdk-11.0.11.9.1-macos-x64.tar.gz        
+        export JAVA_HOME=$PWD/jdk-11.0.11+9/Contents/Home
+    fi
+}
+
+function downloadWindowsJDK16() {
+    platform=$(getPlatform)
+    if [[ "$platform" == 'linux' ]]; then
+        wget https://aka.ms/download-jdk/microsoft-jdk-16.0.1.9.1-linux-x64.tar.gz
+        tar xf microsoft-jdk-16.0.1.9.1-linux-x64.tar.gz
+        export JAVA_HOME=$PWD/jdk-16.0.1+9
+    elif [[ "$platform" == 'darwin' ]]; then
+        wget https://aka.ms/download-jdk/microsoft-jdk-16.0.1.9.1-macos-x64.tar.gz
+        tar xf microsoft-jdk-16.0.1.9.1-macos-x64.tar.gz
+        export JAVA_HOME=$PWD/jdk-16.0.1+9/Contents/Home
     fi
 }
 
@@ -240,7 +276,18 @@ function installForGraalJDK11() {
     cd $dirname
     downloadGraalVMJDK11
     downloadCMake
-    setupTornadoVM graal-jdk-11
+    setupTornadoVM graal-jdk-11-plus
+    setupVariables $dirname
+}
+
+function installForGraalJDK16() {
+    checkPrerequisites
+    dirname="TornadoVM-GraalJDK16"
+    mkdir -p $dirname
+    cd $dirname
+    downloadGraalVMJDK16
+    downloadCMake
+    setupTornadoVM graal-jdk-11-plus
     setupVariables $dirname
 }
 
@@ -250,6 +297,17 @@ function installForCorrettoJDK11() {
     mkdir -p $dirname
     cd $dirname
     downloadCorretto11
+    downloadCMake
+    setupTornadoVM jdk-11-plus
+    setupVariables $dirname
+}
+
+function installForCorrettoJDK16() {
+    checkPrerequisites
+    dirname="TornadoVM-Amazon-Corretto16"
+    mkdir -p $dirname
+    cd $dirname
+    downloadCorretto16
     downloadCMake
     setupTornadoVM jdk-11-plus
     setupVariables $dirname
@@ -277,15 +335,29 @@ function installForWindowsJDK11() {
     setupVariables $dirname
 }
 
+function installForWindowsJDK16() {
+    checkPrerequisites
+    dirname="TornadoVM-Windows-JDK16"
+    mkdir -p $dirname
+    cd $dirname
+    downloadWindowsJDK16
+    downloadCMake
+    setupTornadoVM jdk-11-plus
+    setupVariables $dirname
+}
+
 function printHelp() {
     echo "TornadoVM installer for Linux and OSx"
     echo "Usage:"
     echo "       --jdk8           : Install TornadoVM with OpenJDK 8  (Default)"
-    echo "       --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 20.2.0)"
-    echo "       --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 20.2.0)"
+    echo "       --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 21.1.0)"
+    echo "       --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 21.1.0)"
+    echo "       --graal-jdk-16   : Install TornadoVM with GraalVM and JDK 16 (GraalVM 21.1.0)"
     echo "       --corretto-11    : Install TornadoVM with Corretto JDK 11"
-    echo "       --mandrel-11     : Install TornadoVM with Mandrel 20.2.0 (JDK 11)"
+    echo "       --corretto-16    : Install TornadoVM with Corretto JDK 16"
+    echo "       --mandrel-11     : Install TornadoVM with Mandrel 21.1.0 (JDK 11)"
     echo "       --windows-jdk-11 : Install TornadoVM with Windows JDK 11"
+    echo "       --windows-jdk-16 : Install TornadoVM with Windows JDK 16"
     echo "       --help           : Print this help"
     exit 0
 }
@@ -317,9 +389,17 @@ while [[ $# -gt 0 ]]; do
     installForGraalJDK11
     shift 
     ;;
+  --graal-jdk-16)
+    installForGraalJDK16
+    shift
+    ;;
   --corretto-11)
     installForCorrettoJDK11
     shift 
+    ;;
+  --corretto-16)
+    installForCorrettoJDK16
+    shift
     ;;
   --mandrel-11)
     installForMandrelJDK11
@@ -327,6 +407,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   --windows-jdk-11)
     installForWindowsJDK11
+    shift
+    ;;
+  --windows-jdk-16)
+    installForWindowsJDK16
     shift
     ;;
   *)


### PR DESCRIPTION
This PR provides the following enhancements:
- Update to the JDK links for `Graal 21.1.0`, which is already merged in TornadoVM.
- Extension to the JDK list with support for Amazon Corretto 16, Windows JDK 16. Additionally, JDK8 is currently not supported for Mac OS as GraalVM has stopped the release of the builds.
- Support to build the TornadoVM backends. Users can use `--opencl` and `--ptx` to instruct which backend they want to build.