### PR TITLE
[update/spirv] Added options to build using SPIR-V

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note that GraalVM Community Edition releases based on JDK8 are no longer being b
 ```bash
 TornadoVM installer for Linux and OSx
 Usage:
-       --jdk8           : Install TornadoVM with OpenJDK 8  (Default)
+       --jdk8           : Install TornadoVM with OpenJDK 8
        --jdk11          : Install TornadoVM with OpenJDK 11
        --jdk16          : Install TornadoVM with OpenJDK 16
        --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 21.1.0)

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -265,10 +265,18 @@ function setupTornadoVM() {
 }
 
 function resolveBackends() {
-    if [[ "$opencl" && "$ptx" ]] ; then
-	backend="BACKEND=opencl,ptx"
+    if [[ "$opencl" && "$ptx" && "$spirv" ]] ; then
+        backend="BACKENDS=opencl,ptx,spirv"    
+    elif [[ "$opencl" && "$ptx" ]] ; then
+	backend="BACKENDS=opencl,ptx"
+    elif [[ "$opencl" && "$spirv" ]] ; then
+        backend="BACKENDS=opencl,spirv"
+    elif [[ "$spirv" && "$ptx" ]] ; then
+        backend="BACKENDS=ptx,spirv"
     elif [ "$ptx" ] ; then
         backend="BACKEND=ptx"
+    elif [ "$spirv" ] ; then
+        backend="BACKEND=spirv"
     fi 
 
     if [[ "$backend" == '' ]]; then
@@ -427,6 +435,7 @@ function printHelp() {
     echo "       --windows-jdk-16 : Install TornadoVM with Windows JDK 16"
     echo "       --opencl         : Install TornadoVM and build the OpenCL backend"
     echo "       --ptx            : Install TornadoVM and build the PTX backend"
+    echo "       --spirv          : Install TornadoVM and build the SPIR-V backend"
     echo "       --help           : Print this help"
     exit 0
 }
@@ -439,6 +448,8 @@ do
     opencl=true
   elif [[ "$flag" == '--ptx' ]]; then
     ptx=true
+  elif [[ "$flag" == '--spirv' ]]; then
+    spirv=true
   fi
 done
 }
@@ -511,6 +522,9 @@ do
     shift
     ;;
   --ptx)
+    shift
+    ;;
+  --spirv)
     shift
     ;;
   *)

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -422,7 +422,7 @@ function installForWindowsJDK16() {
 function printHelp() {
     echo "TornadoVM installer for Linux and OSx"
     echo "Usage:"
-    echo "       --jdk8           : Install TornadoVM with OpenJDK 8  (Default)"
+    echo "       --jdk8           : Install TornadoVM with OpenJDK 8"
     echo "       --jdk11          : Install TornadoVM with OpenJDK 11"
     echo "       --jdk16          : Install TornadoVM with OpenJDK 16"
     echo "       --graal-jdk-8    : Install TornadoVM with GraalVM and JDK 8 (GraalVM 21.2.0)"

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -265,23 +265,21 @@ function setupTornadoVM() {
 }
 
 function resolveBackends() {
-    if [[ "$opencl" && "$ptx" && "$spirv" ]] ; then
-        backend="BACKENDS=opencl,ptx,spirv"    
-    elif [[ "$opencl" && "$ptx" ]] ; then
-	backend="BACKENDS=opencl,ptx"
-    elif [[ "$opencl" && "$spirv" ]] ; then
-        backend="BACKENDS=opencl,spirv"
-    elif [[ "$spirv" && "$ptx" ]] ; then
-        backend="BACKENDS=ptx,spirv"
-    elif [ "$ptx" ] ; then
-        backend="BACKEND=ptx"
-    elif [ "$spirv" ] ; then
-        backend="BACKEND=spirv"
-    fi 
-
-    if [[ "$backend" == '' ]]; then
-	backend="BACKEND=opencl"
+    if [ $opencl ]; then
+        b="${b}opencl,"
     fi
+
+    if [ $ptx ]; then
+        b="${b}ptx,"
+    fi
+
+    if [ $spirv ]; then
+        b="${b}spirv,"
+    fi
+
+    # Remove last comma
+    b=${b%?}
+    backend="BACKEND=$b"
 }
 
 function setupVariables() {


### PR DESCRIPTION
This PR adds the options to build TornadoVM with the SPIR-V backend.

This functionality is added by using the `--spirv` option in the `tornadovmInstaller` script.

The `update/spirv` branch is tested internally and will be compatible for the release `v0.12`.