### PR TITLE
Update/displayed/jdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Usage:
        --jdk11          : Install TornadoVM with OpenJDK 11
        --jdk17          : Install TornadoVM with OpenJDK 17
        --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 21.3.0)
-       --graal-jdk-17   : Install TornadoVM with GraalVM and JDK 16 (GraalVM 21.3.0)
+       --graal-jdk-17   : Install TornadoVM with GraalVM and JDK 17 (GraalVM 21.3.0)
        --corretto-11    : Install TornadoVM with Corretto JDK 11
-       --corretto-17    : Install TornadoVM with Corretto JDK 16
+       --corretto-17    : Install TornadoVM with Corretto JDK 17
        --mandrel-11     : Install TornadoVM with Mandrel 21.3.0 (JDK 11)
        --mandrel-17     : Install TornadoVM with Mandrel 21.3.0 (JDK 17)
        --windows-jdk-11 : Install TornadoVM with Windows JDK 11
-       --windows-jdk-17 : Install TornadoVM with Windows JDK 16
+       --windows-jdk-17 : Install TornadoVM with Windows JDK 17
        --opencl         : Install TornadoVM and build the OpenCL backend
        --ptx            : Install TornadoVM and build the PTX backend
        --spirv          : Install TornadoVM and build the SPIR-V backend

--- a/tornadovmInstaller.sh
+++ b/tornadovmInstaller.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#  Copyright (c) 2020-2021, APT Group, Department of Computer Science,
+#  Copyright (c) 2020-2022, APT Group, Department of Computer Science,
 #  The University of Manchester.
 # 
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,7 +126,7 @@ function downloadGraalVMJDK17() {
     elif [[ "$platform" == 'darwin' ]]; then
         wget https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java17-darwin-amd64-21.3.0.tar.gz
         tar -xf graalvm-ce-java17-darwin-amd64-21.3.0.tar.gz
-        export JAVA_HOME=$PWD/graalvm-ce-java16-21.3.0/Contents/Home/
+        export JAVA_HOME=$PWD/graalvm-ce-java17-21.3.0/Contents/Home/
     fi
 }
 
@@ -424,13 +424,13 @@ function printHelp() {
     echo "       --jdk11          : Install TornadoVM with OpenJDK 11"
     echo "       --jdk17          : Install TornadoVM with OpenJDK 17"
     echo "       --graal-jdk-11   : Install TornadoVM with GraalVM and JDK 11 (GraalVM 21.3.0)"
-    echo "       --graal-jdk-17   : Install TornadoVM with GraalVM and JDK 16 (GraalVM 21.3.0)"
+    echo "       --graal-jdk-17   : Install TornadoVM with GraalVM and JDK 17 (GraalVM 21.3.0)"
     echo "       --corretto-11    : Install TornadoVM with Corretto JDK 11"
-    echo "       --corretto-17    : Install TornadoVM with Corretto JDK 16"
+    echo "       --corretto-17    : Install TornadoVM with Corretto JDK 17"
     echo "       --mandrel-11     : Install TornadoVM with Mandrel 21.3.0 (JDK 11)"
     echo "       --mandrel-17     : Install TornadoVM with Mandrel 21.3.0 (JDK 17)"
     echo "       --windows-jdk-11 : Install TornadoVM with Windows JDK 11"
-    echo "       --windows-jdk-17 : Install TornadoVM with Windows JDK 16"
+    echo "       --windows-jdk-17 : Install TornadoVM with Windows JDK 17"
     echo "       --opencl         : Install TornadoVM and build the OpenCL backend"
     echo "       --ptx            : Install TornadoVM and build the PTX backend"
     echo "       --spirv          : Install TornadoVM and build the SPIR-V backend"


### PR DESCRIPTION
This PR provides some fixes:
1. Corrects the display of the jdk version from 16 to 17.
2. Corrects the GraalVM JDK 16 file for Mac OS.